### PR TITLE
PR: 127-install-sass-for-the-main-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "encoding": "^0.1.13",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "sass": "^1.75.0",
     "storybook": "^8.0.4",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: 0.312.0(react@18.2.0)
   next:
     specifier: latest
-    version: 14.1.3(@babel/core@7.24.0)(react-dom@18.2.0)(react@18.2.0)
+    version: 14.1.3(@babel/core@7.24.0)(react-dom@18.2.0)(react@18.2.0)(sass@1.75.0)
   postcss:
     specifier: 8.4.29
     version: 8.4.29
@@ -78,7 +78,7 @@ devDependencies:
     version: 8.0.5(@types/react@18.2.8)(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)
   '@storybook/nextjs':
     specifier: ^8.0.4
-    version: 8.0.5(encoding@0.1.13)(esbuild@0.20.1)(next@14.1.3)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(webpack@5.90.3)
+    version: 8.0.5(encoding@0.1.13)(esbuild@0.20.1)(next@14.1.3)(react-dom@18.2.0)(react@18.2.0)(sass@1.75.0)(typescript@5.1.3)(webpack@5.90.3)
   '@storybook/react':
     specifier: ^8.0.4
     version: 8.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
@@ -115,6 +115,9 @@ devDependencies:
   jest-environment-jsdom:
     specifier: ^29.7.0
     version: 29.7.0
+  sass:
+    specifier: ^1.75.0
+    version: 1.75.0
   storybook:
     specifier: ^8.0.4
     version: 8.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)
@@ -2827,7 +2830,7 @@ packages:
     resolution: {integrity: sha512-eJtf2SaAzOmRV03zn/pFRTqBua8/qy+VDtgaaCFmAyrjsUHO/bcHpbu9vnwP8a+C8ojJnthooi3yz755UTDYYg==}
     dev: true
 
-  /@storybook/nextjs@8.0.5(encoding@0.1.13)(esbuild@0.20.1)(next@14.1.3)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(webpack@5.90.3):
+  /@storybook/nextjs@8.0.5(encoding@0.1.13)(esbuild@0.20.1)(next@14.1.3)(react-dom@18.2.0)(react@18.2.0)(sass@1.75.0)(typescript@5.1.3)(webpack@5.90.3):
     resolution: {integrity: sha512-57lx8avdIqBHlFsJj7fNlrhmAMvCrK+KwZjEi3K4+6h2ORwnOp9HvMW2/b4iAGOB2HxvezjuQJ3XMWLY6Stv2A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -2873,7 +2876,7 @@ packages:
       fs-extra: 11.2.0
       image-size: 1.1.1
       loader-utils: 3.2.1
-      next: 14.1.3(@babel/core@7.24.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.3(@babel/core@7.24.0)(react-dom@18.2.0)(react@18.2.0)(sass@1.75.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.90.3)
       pnp-webpack-plugin: 1.7.0(typescript@5.1.3)
       postcss: 8.4.29
@@ -2882,7 +2885,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
-      sass-loader: 12.6.0(webpack@5.90.3)
+      sass-loader: 12.6.0(sass@1.75.0)(webpack@5.90.3)
       semver: 7.6.0
       sharp: 0.32.6
       style-loader: 3.3.4(webpack@5.90.3)
@@ -5992,7 +5995,7 @@ packages:
     peerDependencies:
       next: '>=13.2.0 <15'
     dependencies:
-      next: 14.1.3(@babel/core@7.24.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.3(@babel/core@7.24.0)(react-dom@18.2.0)(react@18.2.0)(sass@1.75.0)
     dev: false
 
   /gensync@1.0.0-beta.2:
@@ -6399,6 +6402,9 @@ packages:
     dependencies:
       queue: 6.0.2
     dev: true
+
+  /immutable@4.3.5:
+    resolution: {integrity: sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==}
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -7787,7 +7793,7 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /next@14.1.3(@babel/core@7.24.0)(react-dom@18.2.0)(react@18.2.0):
+  /next@14.1.3(@babel/core@7.24.0)(react-dom@18.2.0)(react@18.2.0)(sass@1.75.0):
     resolution: {integrity: sha512-oexgMV2MapI0UIWiXKkixF8J8ORxpy64OuJ/J9oVUmIthXOUCcuVEZX+dtpgq7wIfIqtBwQsKEDXejcjTsan9g==}
     engines: {node: '>=18.17.0'}
     hasBin: true
@@ -7810,6 +7816,7 @@ packages:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+      sass: 1.75.0
       styled-jsx: 5.1.1(@babel/core@7.24.0)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.3
@@ -9092,7 +9099,7 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
-  /sass-loader@12.6.0(webpack@5.90.3):
+  /sass-loader@12.6.0(sass@1.75.0)(webpack@5.90.3):
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -9113,8 +9120,18 @@ packages:
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
+      sass: 1.75.0
       webpack: 5.90.3(esbuild@0.20.1)
     dev: true
+
+  /sass@1.75.0:
+    resolution: {integrity: sha512-ShMYi3WkrDWxExyxSZPst4/okE9ts46xZmJDSawJQrnte7M1V9fScVB+uNXOVKRBt0PggHOwoZcn8mYX4trnBw==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.6.0
+      immutable: 4.3.5
+      source-map-js: 1.0.2
 
   /saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}


### PR DESCRIPTION
Used `pnpm` to install SASS. It is now listed in our `package.json` as a dependency.
![Screenshot of package.json devDependencies with an arrow pointing out SASS](https://github.com/LetsGetTechnical/gridiron-survivor/assets/40150036/7b63edc2-8fdb-4fb0-81d9-3a13c981ad8b)
