### PR TITLE
Fix: updated github action with new vercel preview pacakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,21 +32,23 @@ jobs:
       - name: tests
         run: pnpm test
 
-  test_setup:
-    name: Test setup
+  test-e2e-setup:
+    name: Setup E2E Tests
     runs-on: ubuntu-latest
-    outputs:
-      preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:
       - name: Wait for Vercel Preview
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
-        id: waitForVercelPreviewDeployment
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: zentered/vercel-preview-url@v1.1.9
+        id: vercel_preview_url
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           max_timeout: 600
+        with:
+          vercel_project_id: 'prj_jhk84MWACbySWbHiYbtTXS3UZrYS'
+      - name: Get URL
+        run: echo "https://${{ steps.vercel_preview_url.outputs.preview_url }}"
 
   test_e2e:
-    needs: test_setup
+    needs: test-e2e-setup
     name: Playwright Tests
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           max_timeout: 600
         with:
-          vercel_project_id: 'prj_jhk84MWACbySWbHiYbtTXS3UZrYS'
-          vercel_team_id: 'team_L3yo3uM53cN8XIzRl2HPgSWk'
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel_team_id: ${{ secrets.VERCEL_TEAM_ID }}
       - name: Get URL
         run: echo "https://${{ steps.vercel_preview_url.outputs.preview_url }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           max_timeout: 600
         with:
           vercel_project_id: 'prj_jhk84MWACbySWbHiYbtTXS3UZrYS'
+          vercel_team_id: 'team_L3yo3uM53cN8XIzRl2HPgSWk'
       - name: Get URL
         run: echo "https://${{ steps.vercel_preview_url.outputs.preview_url }}"
 


### PR DESCRIPTION
fixes #293 

Vercel was sending the wrong preview URL and the Playwright Test was failing.  I updated the github action to use a new package using a vercel api key along with our team and project ID for the deployment.

Should grab the correct preview URL now.