### PR TITLE
fix: #319 - removed formData from deleteUser function

### DIFF
--- a/api/serverApiFunctions.test.tsx
+++ b/api/serverApiFunctions.test.tsx
@@ -16,12 +16,8 @@ describe('deleteUser', () => {
     // Set up the mock implementation for the delete method
     (users.delete as jest.Mock).mockResolvedValue(mockResult);
 
-    // Create a mock FormData object
-    const formData = new FormData();
-    formData.append('userId', mockUserId);
-
     // Call the deleteUser function
-    const result = await deleteUser(formData);
+    const result = await deleteUser(mockUserId);
 
     // Assert that the delete method was called with the correct userId
     expect(users.delete).toHaveBeenCalledWith(mockUserId);
@@ -37,12 +33,8 @@ describe('deleteUser', () => {
     // Set up the mock implementation for the delete method to throw an error
     (users.delete as jest.Mock).mockRejectedValue(mockError);
 
-    // Create a mock FormData object
-    const formData = new FormData();
-    formData.append('userId', mockUserId);
-
     // Call the deleteUser function and assert that it throws an error
-    await expect(deleteUser(formData)).rejects.toThrow('Error Deleting User');
+    await expect(deleteUser(mockUserId)).rejects.toThrow('Error Deleting User');
 
     // Assert that the delete method was called with the correct userId
     expect(users.delete).toHaveBeenCalledWith(mockUserId);

--- a/api/serverApiFunctions.ts
+++ b/api/serverApiFunctions.ts
@@ -1,8 +1,8 @@
 'use server';
+import { IUser } from './IapiFunctions';
 import { users } from './serverConfig';
 
-export const deleteUser = async (formData: FormData) => {
-  const userId = formData.get('userId') as string;
+export const deleteUser = async (userId: IUser['id']) => {
   try {
     await users.delete(userId);
     return { success: true };


### PR DESCRIPTION
fixes #319 

This PR fixes the `deleteUser` function from taking in _formData_ to taking in the _userId_ directly so it can be used outside a form if needed.

- updated `serverApiFunctions.ts`
- updated `serverApiFunctions.test.ts`
