### PR TITLE
(fix #321) - Fix Bug For ErrorBoundary

### DIFF
--- a/app/error.test.tsx
+++ b/app/error.test.tsx
@@ -18,6 +18,7 @@ describe('ErrorBoundary', () => {
         }}
       >
         Something went wrong!
+        <button>Reset</button>
       </div>
     );
     render(<ErrorBoundary>{children}</ErrorBoundary>);
@@ -33,6 +34,7 @@ describe('ErrorBoundary', () => {
         }}
       >
         Something went wrong!
+        <button data-testid="reset-button">Reset</button>
       </div>
     );
     render(<ErrorBoundary>{children}</ErrorBoundary>);

--- a/app/error.test.tsx
+++ b/app/error.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ErrorBoundary from './error';
+
+describe('ErrorBoundary', () => {
+  it('should render children when no error occurs', () => {
+    const children = <div>Test</div>;
+    render(<ErrorBoundary>{children}</ErrorBoundary>);
+    expect(screen.getByText('Test')).toBeInTheDocument();
+  });
+
+  it('should render error message when an error occurs', () => {
+    const children = (
+      <div
+        onError={() => {
+          throw new Error('Test error');
+        }}
+      >
+        Something went wrong!
+      </div>
+    );
+    render(<ErrorBoundary>{children}</ErrorBoundary>);
+    expect(
+      screen.getByText('Something went wrong!', { exact: false }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/error.test.tsx
+++ b/app/error.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ErrorBoundary from './error';
+
+let resetButton: HTMLElement;
 
 describe('ErrorBoundary', () => {
   it('should render children when no error occurs', () => {
@@ -23,5 +24,32 @@ describe('ErrorBoundary', () => {
     expect(
       screen.getByText('Something went wrong!', { exact: false }),
     ).toBeInTheDocument();
+  });
+  it('should reset the error state when the reset button is clicked', () => {
+    const children = (
+      <div
+        onError={() => {
+          throw new Error('Test error');
+        }}
+      >
+        Something went wrong!
+      </div>
+    );
+    render(<ErrorBoundary>{children}</ErrorBoundary>);
+    expect(
+      screen.getByText('Something went wrong!', { exact: false }),
+    ).toBeInTheDocument();
+
+    resetButton = screen.getByTestId('reset-button');
+    expect(resetButton).toBeInTheDocument();
+    fireEvent.click(resetButton);
+
+    render(
+      <ErrorBoundary>
+        <div>Test</div>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Test')).toBeInTheDocument();
   });
 });

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -2,25 +2,39 @@
 // Licensed under the MIT License.
 
 'use client';
-import React, { JSX } from 'react';
+import React, { JSX, useState } from 'react';
+
 interface IErrorBoundary {
   children?: React.ReactNode;
 }
 
 /**
- * The error boundary component.
- * @param props - The props
- * @param props.children - The children
- * @returns The rendered error boundary.
+ * Renders an error boundary component that displays an error message if an error occurs within its child components.
+ *
+ * @param {IErrorBoundary} props - The props object containing the children to be rendered.
+ * @returns {JSX.Element} - The rendered error boundary component.
  */
-const ErrorBoundary = (props: IErrorBoundary): JSX.Element => {
-  const { children } = props;
-  return (
-    <div className="align-center flex flex-col">
-      <h2 className="text-white">Something went wrong!</h2>
-      {children}
-    </div>
-  );
+const ErrorBoundary = ({ children }: IErrorBoundary): JSX.Element => {
+  const [hasError, setHasError] = useState(false);
+
+  /**
+   * Sets the `hasError` state to `true`, indicating that an error has occurred.
+   *
+   * @return {void}
+   */
+  const handleError = () => {
+    setHasError(true);
+  };
+
+  if (hasError) {
+    return (
+      <div className="align-center flex flex-col">
+        <h2 className="text-white">Something went wrong!</h2>
+      </div>
+    );
+  }
+
+  return <div onError={handleError}>{children}</div>;
 };
 
 export default ErrorBoundary;

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -2,38 +2,61 @@
 // Licensed under the MIT License.
 
 'use client';
-import React, { JSX, useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { Button } from '@/components/Button/Button';
 
-interface IErrorBoundary {
-  children?: React.ReactNode;
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error | null;
 }
 
 /**
- * Renders an error boundary component that displays an error message if an error occurs within its child components.
+ * A React component that handles errors and renders fallback UI when there's an error.
  *
- * @param {IErrorBoundary} props - The props object containing the children to be rendered.
- * @returns {JSX.Element} - The rendered error boundary component.
+ * @param {ErrorBoundaryProps} children - The children components to render
+ * @returns {React.ReactNode} The rendered output based on error handling
  */
-const ErrorBoundary = ({ children }: IErrorBoundary): JSX.Element => {
-  const [hasError, setHasError] = useState(false);
+const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({ children }) => {
+  const [errorState, setErrorState] = useState<ErrorBoundaryState>({
+    hasError: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    setErrorState({ hasError: false, error: null });
+  }, [children]);
 
   /**
-   * Sets the `hasError` state to `true`, indicating that an error has occurred.
+   * Resets the error state to try again.
    *
-   * @return {void}
+   * @returns {void} No return value.
    */
-  const handleError = (): void => {
-    setHasError(true);
+  const resetErrorBoundary = (): void => {
+    setErrorState({ hasError: false, error: null });
   };
 
-  if (hasError) {
+  if (errorState.hasError) {
     return (
       <div className="align-center flex flex-col">
-        <h2 className="text-white">Something went wrong!</h2>
+        <h2 className="text-white">
+          {errorState.error
+            ? errorState.error.message
+            : 'Something went wrong!'}
+        </h2>
+        <Button
+          data-testid="reset-button"
+          onClick={resetErrorBoundary}
+          label="Try again"
+        />
       </div>
     );
   }
-  return <div onError={handleError}>{children}</div>;
+
+  return <>{children}</>;
 };
 
 export default ErrorBoundary;

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -27,7 +27,13 @@ const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({ children }) => {
   });
 
   useEffect(() => {
-    const handleError = (error: ErrorEvent) => {
+    /**
+     * Handles errors by updating the state with the error information if the error is an instance of Error.
+     *
+     * @param {ErrorEvent} error - The error event to handle.
+     * @return {void} This function does not return anything.
+     */
+    const handleError = (error: ErrorEvent): void => {
       if (error.error instanceof Error) {
         setErrorState({
           hasError: true,
@@ -38,7 +44,7 @@ const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({ children }) => {
     window.addEventListener('error', handleError);
 
     setErrorState({ hasError: false, error: null });
-    return () => {
+    return (): void => {
       window.removeEventListener('error', handleError);
     };
   }, [children]);

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -27,7 +27,20 @@ const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({ children }) => {
   });
 
   useEffect(() => {
+    const handleError = (error: ErrorEvent) => {
+      if (error.error instanceof Error) {
+        setErrorState({
+          hasError: true,
+          error: error.error,
+        });
+      }
+    };
+    window.addEventListener('error', handleError);
+
     setErrorState({ hasError: false, error: null });
+    return () => {
+      window.removeEventListener('error', handleError);
+    };
   }, [children]);
 
   /**

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -33,6 +33,8 @@ const ErrorBoundary = ({ children }: IErrorBoundary): JSX.Element => {
       </div>
     );
   }
+  //!should add componentDidCatch - based off of Web Dev Simplified's
+  //it tracks error to the logs, so you can see which component stack caused it
 
   return <div onError={handleError}>{children}</div>;
 };

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -22,7 +22,7 @@ const ErrorBoundary = ({ children }: IErrorBoundary): JSX.Element => {
    *
    * @return {void}
    */
-  const handleError = () => {
+  const handleError = (): void => {
     setHasError(true);
   };
 
@@ -33,9 +33,6 @@ const ErrorBoundary = ({ children }: IErrorBoundary): JSX.Element => {
       </div>
     );
   }
-  //!should add componentDidCatch - based off of Web Dev Simplified's
-  //it tracks error to the logs, so you can see which component stack caused it
-
   return <div onError={handleError}>{children}</div>;
 };
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -55,11 +55,7 @@ const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({ children }) => {
   if (errorState.hasError) {
     return (
       <div className="align-center flex flex-col">
-        <h2 className="text-white">
-          {errorState.error
-            ? errorState.error.message
-            : 'Something went wrong!'}
-        </h2>
+        <h2 className="text-white">Something went wrong!</h2>
         <Button
           data-testid="reset-button"
           onClick={resetErrorBoundary}


### PR DESCRIPTION
Fix #321 

1. Implemented state: `hasError`
2. Implemented { error, reset } properties to show error.message and reset function to try again
3. Created handleError function set to true
4. Created a unit test file
     4a) added in happy path - where children are able to be rendered successfully
     4b) added in unhappy path - where `Something went wrong!` renders
     4c) added in test to test reset button
     
`Something went wrong!` is no longer being shown in the top left corner     
     
<img width="1074" alt="Screenshot 2024-06-14 at 4 03 42 PM" src="https://github.com/LetsGetTechnical/gridiron-survivor/assets/100221733/a20bb037-1fcc-4b01-916e-f8eb8dcd544b">


What page looks like with error:
<img width="647" alt="image" src="https://github.com/LetsGetTechnical/gridiron-survivor/assets/100221733/ac04d3cf-0831-4289-b038-6fa5ebf00fef">
