### PR TITLE
FIX(#330): Remove useCallback hook from auth context provider

### DIFF
--- a/context/AuthContextProvider.tsx
+++ b/context/AuthContextProvider.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 'use client';
-import React, { JSX, useCallback } from 'react';
+import React, { JSX } from 'react';
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { account } from '@/api/config';
 import { useRouter } from 'next/navigation';
@@ -84,9 +84,9 @@ export const AuthContextProvider = ({
 
   /**
    * Get user data from the session
-   * @returns {Promise<void>}
+   * @returns {Promise<IUser | undefined>} - The user data or undefined if the user is not signed in
    */
-  const getUser = useCallback(async () => {
+  const getUser = async (): Promise<IUser | undefined> => {
     if (!isSessionInLocalStorage()) {
       router.push('/login');
       return;
@@ -101,7 +101,7 @@ export const AuthContextProvider = ({
       resetUser();
       setIsSignedIn(false);
     }
-  }, [user]);
+  };
 
   /**
    * Helper function to validate session data in local storage


### PR DESCRIPTION
fixes #330 

Removed _useCallback_ function from `AuthContextProvider.tsx` as it was not needed and it's dependencies causing more renders than needed.