### PR TITLE
fix(Week.tsx): correct import path for scheduleData try

### DIFF
--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
@@ -70,7 +70,9 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
     }
 
     try {
-      const scheduleData = await import(`@/app/schedule/2024/week${week}.json`);
+      const scheduleData = await import(
+        `@/app/(main)/schedule/2024/week${week}.json`
+      );
       setSchedule(scheduleData.events);
     } catch (error) {
       console.error('Could not load week data:', error);


### PR DESCRIPTION
import path did not follow the new routing structure introduced in #431, this fixes that error.