### PR TITLE
UI/UX: re-implement league entries UI

### DIFF
--- a/app/(main)/league/[leagueId]/entry/all/page.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/all/page.test.tsx
@@ -25,7 +25,7 @@ jest.mock('@/api/apiFunctions', () => ({
 }));
 
 describe('Entry Component', () => {
-  const mockUseDataStore = useDataStore as jest.Mock;
+  const mockUseDataStore = useDataStore as unknown as jest.Mock;
   const mockGetGameWeek = getGameWeek as jest.Mock;
   const mockGetCurrentUserEntries = getCurrentUserEntries as jest.Mock;
 

--- a/app/(main)/league/[leagueId]/entry/all/page.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/all/page.test.tsx
@@ -1,16 +1,22 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import Entry from './page';
 import { useDataStore } from '@/store/dataStore';
-import { getGameWeek, getCurrentUserEntries } from '@/api/apiFunctions';
+import {
+  getGameWeek,
+  getCurrentUserEntries,
+  getCurrentLeague,
+} from '@/api/apiFunctions';
 
 jest.mock('@/store/dataStore', () => ({
   useDataStore: jest.fn(() => ({ user: { id: '123', leagues: [] } })),
 }));
 
 jest.mock('@/api/apiFunctions', () => ({
-  getGameWeek: jest.fn(() =>
+  getCurrentLeague: jest.fn(() =>
     Promise.resolve({
-      week: 1,
+      leagueName: 'Test League',
+      participants: 12,
+      survivors: 10,
     }),
   ),
   getCurrentUserEntries: jest.fn(() =>
@@ -22,12 +28,18 @@ jest.mock('@/api/apiFunctions', () => ({
       },
     ]),
   ),
+  getGameWeek: jest.fn(() =>
+    Promise.resolve({
+      week: 1,
+    }),
+  ),
 }));
 
-describe('Entry Component', () => {
-  const mockUseDataStore = useDataStore as unknown as jest.Mock;
-  const mockGetGameWeek = getGameWeek as jest.Mock;
+describe('League entries page (Entry Component)', () => {
+  const mockGetCurrentLeague = getCurrentLeague as jest.Mock;
   const mockGetCurrentUserEntries = getCurrentUserEntries as jest.Mock;
+  const mockGetGameWeek = getGameWeek as jest.Mock;
+  const mockUseDataStore = useDataStore as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -63,6 +75,100 @@ describe('Entry Component', () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId('global-spinner')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should display the header with the league name, survivors, and week number, without a past weeks link', async () => {
+    mockUseDataStore.mockReturnValueOnce({ user: { id: '123', leagues: [] } });
+    mockGetGameWeek.mockResolvedValueOnce({ week: 1 });
+    mockGetCurrentUserEntries.mockResolvedValueOnce([
+      {
+        id: '66311a210039f0532044',
+        week: 1,
+      },
+    ]);
+    mockGetCurrentLeague.mockResolvedValueOnce({
+      leagueName: 'GiS League',
+      participants: 47,
+      survivors: 47,
+    });
+
+    render(<Entry params={{ leagueId: '66311a210039f0532044' }} />);
+
+    await waitFor(() => {
+      const entryPageHeader = screen.getByTestId('entry-page-header');
+      const entryPageHeaderToLeaguesLink = screen.getByTestId(
+        'entry-page-header-to-leagues-link',
+      );
+      const entryPageHeaderLeagueName = screen.getByTestId(
+        'entry-page-header-league-name',
+      );
+      const entryPageHeaderLeagueSurvivors =
+        screen.getByTestId('LeagueSurvivors');
+      const entryPageHeaderCurrentWeek = screen.getByTestId(
+        'entry-page-header-current-week',
+      );
+
+      expect(entryPageHeader).toBeInTheDocument();
+      expect(entryPageHeaderToLeaguesLink).toBeInTheDocument();
+      expect(entryPageHeaderToLeaguesLink).toHaveAttribute(
+        'href',
+        '/league/all',
+      );
+      expect(entryPageHeaderLeagueName).toBeInTheDocument();
+      expect(entryPageHeaderLeagueName).toHaveTextContent('GiS League');
+      expect(entryPageHeaderLeagueSurvivors).toBeInTheDocument();
+      expect(entryPageHeaderLeagueSurvivors).toHaveTextContent('Survivors');
+      expect(entryPageHeaderCurrentWeek).toBeInTheDocument();
+      expect(entryPageHeaderCurrentWeek).toHaveTextContent('Week 1');
+    });
+  });
+
+  it('should display the header with the league name, survivors, and week number, with a past weeks link', async () => {
+    mockUseDataStore.mockReturnValueOnce({ user: { id: '123', leagues: [] } });
+    mockGetGameWeek.mockResolvedValueOnce({ week: 2 });
+    mockGetCurrentUserEntries.mockResolvedValueOnce([
+      {
+        id: '66311a210039f0532044',
+        week: 2,
+      },
+    ]);
+    mockGetCurrentLeague.mockResolvedValueOnce({
+      leagueName: 'GiS League',
+      participants: 47,
+      survivors: 47,
+    });
+
+    render(<Entry params={{ leagueId: '66311a210039f0532044' }} />);
+
+    await waitFor(() => {
+      const entryPageHeader = screen.getByTestId('entry-page-header');
+      const entryPageHeaderToLeaguesLink = screen.getByTestId(
+        'entry-page-header-to-leagues-link',
+      );
+      const entryPageHeaderLeagueName = screen.getByTestId(
+        'entry-page-header-league-name',
+      );
+      const entryPageHeaderLeagueSurvivors =
+        screen.getByTestId('LeagueSurvivors');
+      const entryPageHeaderCurrentWeek = screen.getByTestId(
+        'entry-page-header-current-week',
+      );
+      const viewPastWeeksLink = screen.getByTestId('past-weeks-link');
+
+      expect(entryPageHeader).toBeInTheDocument();
+      expect(entryPageHeaderToLeaguesLink).toBeInTheDocument();
+      expect(entryPageHeaderToLeaguesLink).toHaveAttribute(
+        'href',
+        '/league/all',
+      );
+      expect(entryPageHeaderLeagueName).toBeInTheDocument();
+      expect(entryPageHeaderLeagueName).toHaveTextContent('GiS League');
+      expect(entryPageHeaderLeagueSurvivors).toBeInTheDocument();
+      expect(entryPageHeaderLeagueSurvivors).toHaveTextContent('Survivors');
+      expect(entryPageHeaderCurrentWeek).toBeInTheDocument();
+      expect(entryPageHeaderCurrentWeek).toHaveTextContent('Week 2');
+      expect(viewPastWeeksLink).toBeInTheDocument();
     });
   });
 });

--- a/app/(main)/league/[leagueId]/entry/all/page.tsx
+++ b/app/(main)/league/[leagueId]/entry/all/page.tsx
@@ -4,18 +4,22 @@
 'use client';
 import {
   createEntry,
+  getCurrentLeague,
   getCurrentUserEntries,
   getGameWeek,
 } from '@/api/apiFunctions';
-import { useDataStore } from '@/store/dataStore';
-import React, { JSX, useEffect, useState } from 'react';
-import { IEntry, IEntryProps } from '../Entries.interface';
-import { LeagueEntries } from '@/components/LeagueEntries/LeagueEntries';
-import { ENTRY_URL, LEAGUE_URL, WEEK_URL } from '@/const/global';
-import { IGameWeek } from '@/api/apiFunctions.interface';
 import { Button } from '@/components/Button/Button';
-import { PlusCircle } from 'lucide-react';
+import { ChevronLeft, PlusCircle } from 'lucide-react';
+import { ENTRY_URL, LEAGUE_URL, WEEK_URL } from '@/const/global';
+import { IEntry, IEntryProps } from '../Entries.interface';
+import { IGameWeek } from '@/api/apiFunctions.interface';
+import { LeagueEntries } from '@/components/LeagueEntries/LeagueEntries';
+import { LeagueSurvivors } from '@/components/LeagueSurvivors/LeagueSurvivors';
+import { useDataStore } from '@/store/dataStore';
 import GlobalSpinner from '@/components/GlobalSpinner/GlobalSpinner';
+import Heading from '@/components/Heading/Heading';
+import Link from 'next/link';
+import React, { JSX, useEffect, useState } from 'react';
 
 /**
  * Display all entries for a league.
@@ -29,8 +33,33 @@ const Entry = ({
 }): JSX.Element => {
   const [currentWeek, setCurrentWeek] = useState<IGameWeek['week']>(1);
   const [entries, setEntries] = useState<IEntry[]>([]);
+  const [leagueName, setLeagueName] = useState<string>('');
   const [loadingData, setLoadingData] = useState<boolean>(true);
+  const [survivors, setSurvivors] = useState<number>(0);
+  const [totalPlayers, setTotalPlayers] = useState<number>(0);
   const { user } = useDataStore((state) => state);
+
+  /**
+   * Fetches the current league name.
+   * @returns {Promise<void>}
+   */
+  useEffect(() => {
+    /**
+     * Fetches the current league name.
+     */
+    const getCurrentLeagueName = async (): Promise<void> => {
+      try {
+        const league = await getCurrentLeague(leagueId);
+        setLeagueName(league.leagueName);
+        setSurvivors(league.survivors.length);
+        setTotalPlayers(league.participants.length);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    getCurrentLeagueName();
+  }, [leagueId]);
 
   /**
    * Fetches all entries for the current user.
@@ -87,7 +116,6 @@ const Entry = ({
     if (!user.id || user.id === '') {
       return;
     }
-
     getCurrentGameWeek();
     getAllEntries();
   }, [user]);
@@ -97,9 +125,35 @@ const Entry = ({
       {loadingData ? (
         <GlobalSpinner />
       ) : (
-        <>
+        <div className="mx-auto max-w-3xl pt-10">
+          <header>
+            <div className="to-leagues-link">
+              <Link
+                className="text-xl text-orange-600 hover:text-orange-500 flex items-center gap-3 font-semibold hover:underline"
+                href={`/league/all`}
+              >
+                <ChevronLeft />
+                Your Leagues
+              </Link>
+            </div>
+            <div className="entries-header-main flex flex-col justify-between text-center gap-10 pt-6 pb-4">
+              <div className="entries-hader-name flex flex-col gap-3">
+                <Heading as="h2" className="text-4xl font-bold">
+                  {leagueName}
+                </Heading>
+                <LeagueSurvivors
+                  className="text-lg font-semibold"
+                  survivors={survivors}
+                  totalPlayers={totalPlayers}
+                />
+              </div>
+              <Heading as="h3" className="text-2xl leading-8 font-semibold">
+                Week {currentWeek}
+              </Heading>
+            </div>
+          </header>
           {entries.length > 0 ? (
-            <>
+            <section className="flex flex-col gap-3">
               {entries.map((entry) => {
                 const linkUrl = `/${LEAGUE_URL}/${leagueId}/${ENTRY_URL}/${entry.$id}/${WEEK_URL}/${currentWeek}`;
                 const isPickSet =
@@ -123,7 +177,7 @@ const Entry = ({
                 );
               })}
 
-              <div className="flex justify-center items-center mt-2 mb-2 w-full">
+              <div className="flex flex-col gap-8 justify-center items-center mt-2 mb-2 w-full">
                 <Button
                   icon={<PlusCircle className="mr-2" />}
                   variant="outline"
@@ -137,8 +191,16 @@ const Entry = ({
                 >
                   Add New Entry
                 </Button>
+                {currentWeek > 1 && (
+                  <Link
+                    className="text-orange-600 hover:text-orange-500 font-bold hover:underline"
+                    href={`#`}
+                  >
+                    View Past Weeks
+                  </Link>
+                )}
               </div>
-            </>
+            </section>
           ) : (
             <div className="flex justify-center items-center mt-2 mb-2 w-full">
               <Button
@@ -156,7 +218,7 @@ const Entry = ({
               </Button>
             </div>
           )}
-        </>
+        </div>
       )}
     </>
   );

--- a/app/(main)/league/[leagueId]/entry/all/page.tsx
+++ b/app/(main)/league/[leagueId]/entry/all/page.tsx
@@ -57,7 +57,7 @@ const Entry = ({
     };
 
     getCurrentLeagueName();
-  }, [leagueId]);
+  });
 
   /**
    * Fetches all entries for the current user.

--- a/app/(main)/league/[leagueId]/entry/all/page.tsx
+++ b/app/(main)/league/[leagueId]/entry/all/page.tsx
@@ -118,6 +118,7 @@ const Entry = ({
     }
     getCurrentGameWeek();
     getAllEntries();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
 
   return (

--- a/app/(main)/league/[leagueId]/entry/all/page.tsx
+++ b/app/(main)/league/[leagueId]/entry/all/page.tsx
@@ -39,13 +39,11 @@ const Entry = ({
   const [totalPlayers, setTotalPlayers] = useState<number>(0);
   const { user } = useDataStore((state) => state);
 
-  /**
-   * Fetches the current league name.
-   * @returns {Promise<void>}
-   */
   useEffect(() => {
     /**
      * Fetches the current league name.
+     * @returns {Promise<void>}
+     * @throws {Error} - An error occurred fetching the league name.
      */
     const getCurrentLeagueName = async (): Promise<void> => {
       try {
@@ -54,7 +52,7 @@ const Entry = ({
         setSurvivors(league.survivors.length);
         setTotalPlayers(league.participants.length);
       } catch (error) {
-        console.error(error);
+        throw new Error(`Error fetching league name: ${error}`);
       }
     };
 

--- a/app/(main)/league/[leagueId]/entry/all/page.tsx
+++ b/app/(main)/league/[leagueId]/entry/all/page.tsx
@@ -127,19 +127,27 @@ const Entry = ({
         <GlobalSpinner />
       ) : (
         <div className="mx-auto max-w-3xl pt-10">
-          <header>
-            <div className="to-leagues-link">
+          <header data-testid="entry-page-header">
+            <div className="entry-page-header-to-leagues-link">
               <Link
                 className="text-xl text-orange-600 hover:text-orange-500 flex items-center gap-3 font-semibold hover:underline"
+                data-testid="entry-page-header-to-leagues-link"
                 href={`/league/all`}
               >
                 <ChevronLeft />
                 Your Leagues
               </Link>
             </div>
-            <div className="entries-header-main flex flex-col justify-between text-center gap-10 pt-6 pb-4">
-              <div className="entries-hader-name flex flex-col gap-3">
-                <Heading as="h2" className="text-4xl font-bold">
+            <div
+              className="entry-page-header-main flex flex-col justify-between text-center gap-10 pt-6 pb-4"
+              data-testid="entry-page-header-main"
+            >
+              <div className="entry-page-header-league-name-and-survivors flex flex-col gap-3">
+                <Heading
+                  as="h2"
+                  className="text-4xl font-bold"
+                  data-testid="entry-page-header-league-name"
+                >
                   {leagueName}
                 </Heading>
                 <LeagueSurvivors
@@ -148,7 +156,11 @@ const Entry = ({
                   totalPlayers={totalPlayers}
                 />
               </div>
-              <Heading as="h3" className="text-2xl leading-8 font-semibold">
+              <Heading
+                as="h3"
+                className="text-2xl leading-8 font-semibold"
+                data-testid="entry-page-header-current-week"
+              >
                 Week {currentWeek}
               </Heading>
             </div>
@@ -195,6 +207,7 @@ const Entry = ({
                 {currentWeek > 1 && (
                   <Link
                     className="text-orange-600 hover:text-orange-500 font-bold hover:underline"
+                    data-testid="past-weeks-link"
                     href={`#`}
                   >
                     View Past Weeks


### PR DESCRIPTION
# Re-Implement League Entries UI/UX
Closes #443 
My previous UI implementation was not carried over when the page was made interactive and filled with data, therefore, I had to re-implement it.

## Week 1 State
![Arc GridIron Survivor-000116](https://github.com/user-attachments/assets/5ddb2dc5-c7d6-484f-b1d3-2ba0e802b776)

## Week 2+ State
If `currentWeek` is great than one, it should display a link to view past week's picks
![Arc GridIron Survivor-000120](https://github.com/user-attachments/assets/1c307b06-7aff-4b82-b19a-b38fdcc69cbb)

## To Do
- [X] Double-check that my code is accurate to the design.
- [X] Add tests.