### PR TITLE
Alex/add redirect for team selections

### DIFF
--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.test.tsx
@@ -224,18 +224,15 @@ describe('Week', () => {
   });
 
   test('should redirect back to entry page after successfully selecting a team', async () => {
-    mockUseAuthContext.isSignedIn = true;
-    mockCreateWeeklyPicks.mockResolvedValue({});
-
     render(
       <Week entry={entry} league={league} NFLTeams={NFLTeams} week={week} />,
     );
 
-    const selectedTeam = screen.getByTestId('team-pick');
-    fireEvent.click(selectedTeam);
+    const selectedTeam = await screen.findAllByTestId('team-radio');
+    fireEvent.click(selectedTeam[0]);
 
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith(`/league/${league}/entry/all`);
-    });
+    })
   });
 });

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.test.tsx
@@ -228,8 +228,8 @@ describe('Week', () => {
       <Week entry={entry} league={league} NFLTeams={NFLTeams} week={week} />,
     );
 
-    const selectedTeam = await screen.findAllByTestId('team-radio');
-    fireEvent.click(selectedTeam[0]);
+    const teamRadios = await screen.findAllByTestId('team-radio');
+    fireEvent.click(teamRadios[0]);
 
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith(`/league/${league}/entry/all`);

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import Week from './Week';
 import {
@@ -14,6 +14,16 @@ import { toast } from 'react-hot-toast';
 import { onWeeklyPickChange } from './WeekHelper';
 import { parseUserPick } from '@/utils/utils';
 import { IWeeklyPicks } from '@/api/apiFunctions.interface';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter() {
+    return {
+      push: mockPush,
+    };
+  },
+}));
 
 const mockUseAuthContext = {
   isSignedIn: false,
@@ -211,5 +221,21 @@ describe('Week', () => {
         message="There was an error processing your request."
       />,
     );
+  });
+
+  test('should redirect back to entry page after successfully selecting a team', async () => {
+    mockUseAuthContext.isSignedIn = true;
+    mockCreateWeeklyPicks.mockResolvedValue({});
+
+    render(
+      <Week entry={entry} league={league} NFLTeams={NFLTeams} week={week} />,
+    );
+
+    const selectedTeam = screen.getByTestId('team-pick');
+    fireEvent.click(selectedTeam);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(`/league/${league}/entry/all`);
+    });
   });
 });

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
@@ -15,8 +15,6 @@ import { IWeekProps } from './Week.interface';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useDataStore } from '@/store/dataStore';
 import { ISchedule } from './WeekTeams.interface';
-import LinkCustom from '@/components/LinkCustom/LinkCustom';
-import { ChevronLeft } from 'lucide-react';
 import {
   getAllWeeklyPicks,
   getCurrentUserEntries,
@@ -31,6 +29,7 @@ import Alert from '@/components/AlertNotification/AlertNotification';
 import { AlertVariants } from '@/components/AlertNotification/Alerts.enum';
 import { NFLTeams } from '@/api/apiFunctions.enum';
 import { useAuthContext } from '@/context/AuthContextProvider';
+import { useRouter } from 'next/navigation';
 
 /**
  * Renders the weekly picks page.
@@ -48,6 +47,7 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
   const { user, updateCurrentWeek, updateWeeklyPicks, weeklyPicks } =
     useDataStore((state) => state);
   const { isSignedIn } = useAuthContext();
+  const router = useRouter();
 
   /**
    * Fetches the current game week.
@@ -183,6 +183,7 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
     try {
       await onWeeklyPickChange(params);
       setUserPick(teamSelect);
+      router.push(`/league/${league}/entry/all`);
     } catch (error) {
       console.error('Submission error:', error);
     }
@@ -218,17 +219,6 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
         <GlobalSpinner data-testid="global-spinner" />
       ) : (
         <>
-          <nav className="py-6 text-primary hover:no-underline">
-            <LinkCustom
-              className="no-underline hover:underline text-primary flex gap-3 items-center font-semibold text-xl"
-              href={`/league/${league}/entry/all`}
-            >
-              <span aria-hidden="true">
-                <ChevronLeft size={16} />
-              </span>
-              {selectedLeague?.leagueName as string}
-            </LinkCustom>
-          </nav>
           <section className="w-full pt-8" data-testid="weekly-picks">
             <h1 className="pb-8 text-center text-[2rem] font-bold text-foreground">
               Week {week} pick
@@ -248,6 +238,7 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
                           field={field}
                           userPick={userPick}
                           onWeeklyPickChange={handleWeeklyPickChange}
+                          data-testid="team-pick"
                         />
                       </FormControl>
                       <FormMessage />

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
@@ -238,7 +238,6 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
                           field={field}
                           userPick={userPick}
                           onWeeklyPickChange={handleWeeklyPickChange}
-                          data-testid="team-pick"
                         />
                       </FormControl>
                       <FormMessage />

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
@@ -30,6 +30,8 @@ import { AlertVariants } from '@/components/AlertNotification/Alerts.enum';
 import { NFLTeams } from '@/api/apiFunctions.enum';
 import { useAuthContext } from '@/context/AuthContextProvider';
 import { useRouter } from 'next/navigation';
+import LinkCustom from '@/components/LinkCustom/LinkCustom';
+import { ChevronLeft } from 'lucide-react';
 
 /**
  * Renders the weekly picks page.
@@ -219,6 +221,17 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
         <GlobalSpinner data-testid="global-spinner" />
       ) : (
         <>
+          <nav className="py-6 text-primary hover:no-underline">
+            <LinkCustom
+              className="no-underline hover:underline text-primary flex gap-3 items-center font-semibold text-xl"
+              href={`/league/${league}/entry/all`}
+            >
+              <span aria-hidden="true">
+                <ChevronLeft size={16} />
+              </span>
+              {selectedLeague?.leagueName as string}
+            </LinkCustom>
+          </nav>
           <section className="w-full pt-8" data-testid="weekly-picks">
             <h1 className="pb-8 text-center text-[2rem] font-bold text-foreground">
               Week {week} pick


### PR DESCRIPTION
Closes #515 

Redirect user to the league home after they make a successful pick. Allowing users to make selections to their Entries faster.

- [x] Added router.push to the handleWeeklyPickChange function to redirect the user back to their entry page.
- [x] For testing I had to grab the 'team-radio' test id and had to use "findAll" because I had to await it to simulate the page loading and there are multiple team radio's.
- [x] Then in that same test, I had to put selectedTeams[0] to simulate me clicking the first team option. The [0] is the index.


https://github.com/user-attachments/assets/3ef29b76-1b93-4e0d-8cef-f010964ba4de

