### PR TITLE
Richard/loading team input

### DIFF
--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.interface.ts
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.interface.ts
@@ -23,12 +23,12 @@ export interface IWeeklyPickChange {
   entry: string;
   league: string;
   NFLTeams: INFLTeam[];
+  setLoadingTeamName: React.Dispatch<React.SetStateAction<string | null>>;
   setUserPick: React.Dispatch<React.SetStateAction<string>>;
   updateWeeklyPicks: ({}: IWeeklyPicks) => void;
   user: IUser;
   weeklyPicks: IWeeklyPicks;
   week: string;
-  setLoadingTeamName: (loadData: string | null) => void;
 }
 
 export interface IWeekProps {

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.interface.ts
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.interface.ts
@@ -28,6 +28,7 @@ export interface IWeeklyPickChange {
   user: IUser;
   weeklyPicks: IWeeklyPicks;
   week: string;
+  setLoadingTeamName: (loadData: string | null) => void;
 }
 
 export interface IWeekProps {

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
@@ -31,8 +31,6 @@ import { useAuthContext } from '@/context/AuthContextProvider';
 import LinkCustom from '@/components/LinkCustom/LinkCustom';
 import { ChevronLeft } from 'lucide-react';
 import toast from 'react-hot-toast';
-import { onWeeklyPickChange } from './WeekHelper';
-import { useRouter } from 'next/navigation';
 
 /**
  * Renders the weekly picks page.
@@ -51,7 +49,6 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
   const { user, updateCurrentWeek, updateWeeklyPicks, weeklyPicks } =
     useDataStore((state) => state);
   const { isSignedIn } = useAuthContext();
-  const router = useRouter();
 
   /**
    * Fetches the current game week.
@@ -193,8 +190,6 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
         />,
       );
       console.error(params);
-      onWeeklyPickChange(params);
-      router.push(`/league/${league}/entry/all`);
     } catch (error) {
       console.error('Submission error:', error);
     }

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
@@ -31,6 +31,8 @@ import { useAuthContext } from '@/context/AuthContextProvider';
 import LinkCustom from '@/components/LinkCustom/LinkCustom';
 import { ChevronLeft } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { onWeeklyPickChange } from './WeekHelper';
+import { useRouter } from 'next/navigation';
 
 /**
  * Renders the weekly picks page.
@@ -49,6 +51,7 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
   const { user, updateCurrentWeek, updateWeeklyPicks, weeklyPicks } =
     useDataStore((state) => state);
   const { isSignedIn } = useAuthContext();
+  const router = useRouter();
 
   /**
    * Fetches the current game week.
@@ -190,6 +193,8 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
         />,
       );
       console.error(params);
+      onWeeklyPickChange(params);
+      router.push(`/league/${league}/entry/all`);
     } catch (error) {
       console.error('Submission error:', error);
     }

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
@@ -176,12 +176,12 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
       entry,
       league,
       NFLTeams,
+      setLoadingTeamName,
       setUserPick,
       updateWeeklyPicks,
       user,
       weeklyPicks,
       week,
-      setLoadingTeamName: setLoadingTeamName,
     };
 
     try {

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
@@ -179,11 +179,11 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
       user,
       weeklyPicks,
       week,
-      setLoadingTeamName: setLoadingTeamName
+      setLoadingTeamName: setLoadingTeamName,
     };
 
     try {
-      await onWeeklyPickChange(params)
+      await onWeeklyPickChange(params);
     } catch (error) {
       console.error('Submission error:', error);
     }
@@ -195,7 +195,7 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
       return;
     }
     getSchedule(week);
-  }, [week, selectedLeague, loadingTeamName]);
+  }, [week, selectedLeague]);
 
   useEffect(() => {
     if (isSignedIn) {
@@ -203,7 +203,7 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
       getUserSelectedTeams();
       getUserWeeklyPick();
     }
-  }, [isSignedIn, userPick]);
+  }, [isSignedIn]);
 
   if (loadingData) {
     return <GlobalSpinner />;

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/Week.tsx
@@ -44,6 +44,7 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
   const [selectedLeague, setSelectedLeague] = useState<ILeague | undefined>();
   const [selectedTeams, setSelectedTeams] = useState<string[]>([]);
   const [loadingData, setLoadingData] = useState<boolean>(true);
+  const [loadingTeamName, setLoadingTeamName] = useState<string | null>(null);
   const [userPick, setUserPick] = useState<string>('');
   const { user, updateCurrentWeek, updateWeeklyPicks, weeklyPicks } =
     useDataStore((state) => state);
@@ -178,10 +179,11 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
       user,
       weeklyPicks,
       week,
+      setLoadingTeamName: setLoadingTeamName
     };
 
     try {
-      await onWeeklyPickChange(params);
+      await onWeeklyPickChange(params)
     } catch (error) {
       console.error('Submission error:', error);
     }
@@ -193,7 +195,7 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
       return;
     }
     getSchedule(week);
-  }, [week, selectedLeague]);
+  }, [week, selectedLeague, loadingTeamName]);
 
   useEffect(() => {
     if (isSignedIn) {
@@ -201,7 +203,7 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
       getUserSelectedTeams();
       getUserWeeklyPick();
     }
-  }, [isSignedIn]);
+  }, [isSignedIn, userPick]);
 
   if (loadingData) {
     return <GlobalSpinner />;
@@ -242,6 +244,7 @@ const Week = ({ entry, league, NFLTeams, week }: IWeekProps): JSX.Element => {
                     <FormItem>
                       <FormControl>
                         <WeekTeams
+                          loadingTeamName={loadingTeamName}
                           schedule={schedule}
                           selectedTeams={selectedTeams}
                           field={field}

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekHelper.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekHelper.tsx
@@ -37,13 +37,16 @@ export const onWeeklyPickChange = async ({
   user,
   weeklyPicks,
   week,
+  setLoadingTeamName: setLoadingTeamName,
 }: IWeeklyPickChange): Promise<void> => {
   try {
-    const teamID = NFLTeams.find(
+    const team = NFLTeams.find(
       (team) => team.teamName === teamSelect,
-    )?.teamName;
+    );
 
-    const currentUserPick = parseUserPick(user.id, entry, teamID || '');
+    setLoadingTeamName(team?.teamId ?? null)
+
+    const currentUserPick = parseUserPick(user.id, entry, team?.teamName || '');
 
     // combines current picks and the user pick into one object.
     // if the user pick exists then it overrides the pick of the user.
@@ -105,5 +108,7 @@ export const onWeeklyPickChange = async ({
         message="There was an error processing your request."
       />,
     );
-  }
+  } finally {
+      setLoadingTeamName(null);
+  }  
 };

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekHelper.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekHelper.tsx
@@ -44,7 +44,7 @@ export const onWeeklyPickChange = async ({
       (team) => team.teamName === teamSelect,
     );
 
-    setLoadingTeamName(team?.teamId ?? null)
+    setLoadingTeamName(team?.teamId ?? null);
 
     const currentUserPick = parseUserPick(user.id, entry, team?.teamName || '');
 
@@ -95,9 +95,8 @@ export const onWeeklyPickChange = async ({
     toast.custom(
       <Alert
         variant={AlertVariants.Success}
-        message={`You have successfully pick the ${
-          currentUserPick[user.id][entry].teamName
-        } for your team!`}
+        message={`You have successfully pick the ${currentUserPick[user.id][entry].teamName
+          } for your team!`}
       />,
     );
   } catch (error) {
@@ -109,6 +108,6 @@ export const onWeeklyPickChange = async ({
       />,
     );
   } finally {
-      setLoadingTeamName(null);
-  }  
+    setLoadingTeamName(null);
+  }
 };

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekHelper.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekHelper.tsx
@@ -33,12 +33,12 @@ export const onWeeklyPickChange = async ({
   entry,
   league,
   NFLTeams,
+  setLoadingTeamName,
   setUserPick,
   updateWeeklyPicks,
   user,
   weeklyPicks,
   week,
-  setLoadingTeamName: setLoadingTeamName,
 }: IWeeklyPickChange): Promise<void> => {
   try {
     const team = NFLTeams.find((team) => team.teamName === teamSelect);

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekHelper.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekHelper.tsx
@@ -25,6 +25,7 @@ import { IWeeklyPickChange } from './Week.interface';
  * @param props.week - Prop value for gameWeekId in updateWeeklyPicks
  * @param props.updateWeeklyPicks - Prop for the updateWeeklyPicks function
  * @param props.setUserPick - Prop for the setUserPick function
+ * @param props.setLoadingTeamName - Prop for the setLoadingTeamName state
  * @returns {void}
  */
 export const onWeeklyPickChange = async ({
@@ -40,9 +41,7 @@ export const onWeeklyPickChange = async ({
   setLoadingTeamName: setLoadingTeamName,
 }: IWeeklyPickChange): Promise<void> => {
   try {
-    const team = NFLTeams.find(
-      (team) => team.teamName === teamSelect,
-    );
+    const team = NFLTeams.find((team) => team.teamName === teamSelect);
 
     setLoadingTeamName(team?.teamId ?? null);
 
@@ -95,8 +94,9 @@ export const onWeeklyPickChange = async ({
     toast.custom(
       <Alert
         variant={AlertVariants.Success}
-        message={`You have successfully pick the ${currentUserPick[user.id][entry].teamName
-          } for your team!`}
+        message={`You have successfully pick the ${
+          currentUserPick[user.id][entry].teamName
+        } for your team!`}
       />,
     );
   } catch (error) {

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.interface.ts
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.interface.ts
@@ -27,12 +27,12 @@ export interface ISchedule {
 
 export interface IWeekTeamsProps {
   field: ControllerRenderProps<FieldValues, string>;
+  loadingTeamName: string | null;
+  onWeeklyPickChange: ({}: NFLTeams) => Promise<void>;
   schedule: ISchedule[];
   selectedTeams: INFLTeam['teamName'][];
   userPick: string;
   // eslint-disable-next-line no-unused-vars
-  onWeeklyPickChange: (teamSelect: NFLTeams) => Promise<void>;
-  loadingTeamName: string | null;
 }
 
 interface ICompetition {

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.interface.ts
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.interface.ts
@@ -32,6 +32,7 @@ export interface IWeekTeamsProps {
   userPick: string;
   // eslint-disable-next-line no-unused-vars
   onWeeklyPickChange: (teamSelect: NFLTeams) => Promise<void>;
+  loadingTeamName: string | null;
 }
 
 interface ICompetition {

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
@@ -111,7 +111,7 @@ describe('WeekTeams', () => {
       render(<TestWeekTeamsComponent />);
 
       await waitFor(() => {
-        expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('loading-spinner')).toBeInTheDocument();
       });
     });
 

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, useState as useStateMock } from 'react';
+import React, { useState as useStateMock } from 'react'
 import WeekTeams from './WeekTeams';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { mockSchedule } from './__mocks__/mockSchedule';
@@ -24,12 +24,12 @@ const mockDefaultUserPick = 'Ravens';
 const mockNewUserPick = 'Chiefs';
 const mockOnWeeklyPickChange = jest.fn();
 const mockHasTeamBeenPicked = hasTeamBeenPicked as jest.Mock;
-const mockLoadingTeamName = '';
+const mockLoadingTeamName = null;
 const setTeamLoadingName = jest.fn();
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
-  useState: jest.fn().mockImplementation((init) => [init, setTeamLoadingName]),
+  useState: jest.fn(),
 }));
 
 const TestWeekTeamsComponent = () => {
@@ -105,23 +105,33 @@ describe('WeekTeams', () => {
   });
 
   describe('team loading spinner', () => {
+
+    beforeEach(() => {
+      (useStateMock as jest.Mock).mockImplementation(init => [init, setTeamLoadingName])
+    });
+  
     it('should show the loading spinner', async () => {
-      jest.fn().mockImplementationOnce(() => ['packers', setTeamLoadingName]);
+      jest.spyOn(React, 'useState').mockImplementationOnce(() => ['packers', setTeamLoadingName]);
 
       render(<TestWeekTeamsComponent />);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('loading-spinner')).toBeInTheDocument();
-      });
+    const teamRadios = screen.getAllByTestId('team-radio');
+
+    expect(teamRadios).toBeInTheDocument();
+    // fireEvent.click(teamRadios[0]);
+
+    // const loadingSpinner = await screen.findByTestId('loading-spinner');
+
+    // expect(loadingSpinner).toBeInTheDocument();
     });
 
     it('should not show the loading spinner', async () => {
-      jest.fn().mockImplementationOnce(() => ['ravens', setTeamLoadingName]);
+      jest.spyOn(React, 'useState').mockImplementationOnce(() => ['ravens', setTeamLoadingName]);
 
       render(<TestWeekTeamsComponent />);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+      await waitFor(async() => {
+        expect(await screen.findByTestId('loading-spinner')).not.toBeInTheDocument();
       });
     });
   });

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
@@ -100,15 +100,4 @@ describe('WeekTeams', () => {
     expect(packersButton).toBeDisabled();
   });
 
-  describe('loading spinner team selection', () => {
-    it('the loading spinner should display after team selection', () => {
-      render(<TestWeekTeamsComponent loadingTeamName={'packers'} />);
-      expect(screen.queryByTestId('loading-spinner')).toBeInTheDocument();
-    });
-
-    it('the loading spinner should not display after team selection', () => {
-      render(<TestWeekTeamsComponent loadingTeamName={''} />);
-      expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
-    });
-  });
 });

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
@@ -24,7 +24,11 @@ const mockNewUserPick = 'Chiefs';
 const mockOnWeeklyPickChange = jest.fn();
 const mockHasTeamBeenPicked = hasTeamBeenPicked as jest.Mock;
 
-const TestWeekTeamsComponent = ({loadingTeamName}:{loadingTeamName: string}) => {
+const TestWeekTeamsComponent = ({
+  loadingTeamName,
+}: {
+  loadingTeamName: string;
+}) => {
   const formMethods = useForm();
   return (
     <FormProvider {...formMethods}>
@@ -98,14 +102,13 @@ describe('WeekTeams', () => {
 
   describe('loading spinner team selection', () => {
     it('the loading spinner should display after team selection', () => {
-      render(<TestWeekTeamsComponent loadingTeamName={'packers'}/>);
+      render(<TestWeekTeamsComponent loadingTeamName={'packers'} />);
       expect(screen.queryByTestId('loading-spinner')).toBeInTheDocument();
     });
 
     it('the loading spinner should display after team selection', () => {
-      render(<TestWeekTeamsComponent loadingTeamName={''}/>);
+      render(<TestWeekTeamsComponent loadingTeamName={''} />);
       expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
     });
   });
-
 });

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
@@ -9,7 +9,7 @@ jest.mock('@/utils/utils', () => ({
   hasTeamBeenPicked: jest.fn(),
   cn: jest.fn(),
 }));
-  
+
 const mockField = {
   name: 'value',
   value: '',
@@ -24,13 +24,12 @@ const mockDefaultUserPick = 'Ravens';
 const mockNewUserPick = 'Chiefs';
 const mockOnWeeklyPickChange = jest.fn();
 const mockHasTeamBeenPicked = hasTeamBeenPicked as jest.Mock;
-const setState = jest.fn();
 const mockLoadingTeamName = '';
-const mockSetTeamName = jest.fn();
+const setTeamLoadingName = jest.fn();
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
-  useState: jest.fn().mockImplementation((init) => [init, mockSetTeamName]),
+  useState: jest.fn().mockImplementation((init) => [init, setTeamLoadingName]),
 }));
 
 const TestWeekTeamsComponent = () => {
@@ -50,11 +49,6 @@ const TestWeekTeamsComponent = () => {
 };
 
 describe('WeekTeams', () => {
-  const useStateMock = (init: any): [unknown, Dispatch<unknown>] => [
-    init,
-    setState,
-  ];
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -112,7 +106,7 @@ describe('WeekTeams', () => {
 
   describe('team loading spinner', () => {
     it('should show the loading spinner', async () => {
-      jest.fn().mockImplementationOnce(() => ['packers', mockSetTeamName]);
+      jest.fn().mockImplementationOnce(() => ['packers', setTeamLoadingName]);
 
       render(<TestWeekTeamsComponent />);
 
@@ -122,7 +116,7 @@ describe('WeekTeams', () => {
     });
 
     it('should not show the loading spinner', async () => {
-      jest.fn().mockImplementationOnce(() => ['ravens', mockSetTeamName]);
+      jest.fn().mockImplementationOnce(() => ['ravens', setTeamLoadingName]);
 
       render(<TestWeekTeamsComponent />);
 

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
@@ -23,12 +23,14 @@ const mockDefaultUserPick = 'Ravens';
 const mockNewUserPick = 'Chiefs';
 const mockOnWeeklyPickChange = jest.fn();
 const mockHasTeamBeenPicked = hasTeamBeenPicked as jest.Mock;
+const mockLoadingTeamName = 'packers';
 
 const TestWeekTeamsComponent = () => {
   const formMethods = useForm();
   return (
     <FormProvider {...formMethods}>
       <WeekTeams
+        loadingTeamName={mockLoadingTeamName}
         field={mockField}
         schedule={mockSchedule}
         selectedTeams={mockSelectedTeams}

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
@@ -106,7 +106,7 @@ describe('WeekTeams', () => {
       expect(screen.queryByTestId('loading-spinner')).toBeInTheDocument();
     });
 
-    it('the loading spinner should display after team selection', () => {
+    it('the loading spinner should not display after team selection', () => {
       render(<TestWeekTeamsComponent loadingTeamName={''} />);
       expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
     });

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
@@ -1,6 +1,5 @@
-import React, { useState as useStateMock } from 'react'
 import WeekTeams from './WeekTeams';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { mockSchedule } from './__mocks__/mockSchedule';
 import { FormProvider, useForm } from 'react-hook-form';
 import { hasTeamBeenPicked, cn } from '@/utils/utils';
@@ -24,20 +23,13 @@ const mockDefaultUserPick = 'Ravens';
 const mockNewUserPick = 'Chiefs';
 const mockOnWeeklyPickChange = jest.fn();
 const mockHasTeamBeenPicked = hasTeamBeenPicked as jest.Mock;
-const mockLoadingTeamName = null;
-const setTeamLoadingName = jest.fn();
 
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useState: jest.fn(),
-}));
-
-const TestWeekTeamsComponent = () => {
+const TestWeekTeamsComponent = ({loadingTeamName}:{loadingTeamName: string}) => {
   const formMethods = useForm();
   return (
     <FormProvider {...formMethods}>
       <WeekTeams
-        loadingTeamName={mockLoadingTeamName}
+        loadingTeamName={loadingTeamName}
         field={mockField}
         schedule={mockSchedule}
         selectedTeams={mockSelectedTeams}
@@ -56,7 +48,7 @@ describe('WeekTeams', () => {
   it('the team should render active and the user currently has them selected', () => {
     mockHasTeamBeenPicked.mockReturnValue(false);
 
-    render(<TestWeekTeamsComponent />);
+    render(<TestWeekTeamsComponent loadingTeamName={''} />);
 
     const weekTeamsRadioItems: HTMLButtonElement[] =
       screen.getAllByTestId('team-radio');
@@ -73,7 +65,7 @@ describe('WeekTeams', () => {
   it('the team should render active and the user should be able to select the team', () => {
     mockHasTeamBeenPicked.mockReturnValue(false);
 
-    render(<TestWeekTeamsComponent />);
+    render(<TestWeekTeamsComponent loadingTeamName={''} />);
     const weeklyPickButtons = screen.getAllByTestId('team-label');
 
     const chiefsButton = weeklyPickButtons.filter(
@@ -91,7 +83,7 @@ describe('WeekTeams', () => {
   it('the team should render disabled if the team has already been used and the user should not be able to select the team', () => {
     mockHasTeamBeenPicked.mockReturnValue(true);
 
-    render(<TestWeekTeamsComponent />);
+    render(<TestWeekTeamsComponent loadingTeamName={''} />);
 
     const weeklyPickButtons: HTMLButtonElement[] =
       screen.getAllByTestId('team-radio');
@@ -104,35 +96,16 @@ describe('WeekTeams', () => {
     expect(packersButton).toBeDisabled();
   });
 
-  describe('team loading spinner', () => {
-
-    beforeEach(() => {
-      (useStateMock as jest.Mock).mockImplementation(init => [init, setTeamLoadingName])
-    });
-  
-    it('should show the loading spinner', async () => {
-      jest.spyOn(React, 'useState').mockImplementationOnce(() => ['packers', setTeamLoadingName]);
-
-      render(<TestWeekTeamsComponent />);
-
-    const teamRadios = screen.getAllByTestId('team-radio');
-
-    expect(teamRadios).toBeInTheDocument();
-    // fireEvent.click(teamRadios[0]);
-
-    // const loadingSpinner = await screen.findByTestId('loading-spinner');
-
-    // expect(loadingSpinner).toBeInTheDocument();
+  describe('loading spinner team selection', () => {
+    it('the loading spinner should display after team selection', () => {
+      render(<TestWeekTeamsComponent loadingTeamName={'packers'}/>);
+      expect(screen.queryByTestId('loading-spinner')).toBeInTheDocument();
     });
 
-    it('should not show the loading spinner', async () => {
-      jest.spyOn(React, 'useState').mockImplementationOnce(() => ['ravens', setTeamLoadingName]);
-
-      render(<TestWeekTeamsComponent />);
-
-      await waitFor(async() => {
-        expect(await screen.findByTestId('loading-spinner')).not.toBeInTheDocument();
-      });
+    it('the loading spinner should display after team selection', () => {
+      render(<TestWeekTeamsComponent loadingTeamName={''}/>);
+      expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
     });
   });
+
 });

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.test.tsx
@@ -3,8 +3,13 @@ import WeekTeams from './WeekTeams';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { mockSchedule } from './__mocks__/mockSchedule';
 import { FormProvider, useForm } from 'react-hook-form';
-import { hasTeamBeenPicked } from '@/utils/utils';
+import { hasTeamBeenPicked, cn } from '@/utils/utils';
 
+jest.mock('@/utils/utils', () => ({
+  hasTeamBeenPicked: jest.fn(),
+  cn: jest.fn(),
+}));
+  
 const mockField = {
   name: 'value',
   value: '',

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Gridiron Survivor.
 // Licensed under the MIT License.
 
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import React, { JSX } from 'react';
 import { FormItem, FormControl } from '@/components/Form/Form';
 import { RadioGroup } from '@radix-ui/react-radio-group';
@@ -8,7 +9,6 @@ import { IWeekTeamsProps } from './WeekTeams.interface';
 import { WeeklyPickButton } from '@/components/WeeklyPickButton/WeeklyPickButton';
 import { hasTeamBeenPicked } from '@/utils/utils';
 import { NFLTeams } from '@/api/apiFunctions.enum';
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 
 /**
  * Formats the date to 'day, mon date' format and the time to either 12 or 24-hour format based on the user's locale.
@@ -71,15 +71,19 @@ const WeekTeams = ({
         {scheduledGame.competitions[0].competitors.map((competition) => (
           <FormItem key={competition.id}>
             <FormControl>
-              {loadingTeamName === competition.team.shortDisplayName.toLowerCase() ? <LoadingSpinner/> : 
-              <WeeklyPickButton
-                team={competition.team.name}
-                src={competition.team.logo}
-                isDisabled={Boolean(loadingTeamName) || hasTeamBeenPicked(
-                  competition.team.name,
-                  selectedTeams,
-                )}
-              />}
+              {loadingTeamName ===
+              competition.team.shortDisplayName.toLowerCase() ? (
+                <LoadingSpinner />
+              ) : (
+                <WeeklyPickButton
+                  team={competition.team.name}
+                  src={competition.team.logo}
+                  isDisabled={
+                    Boolean(loadingTeamName) ||
+                    hasTeamBeenPicked(competition.team.name, selectedTeams)
+                  }
+                />
+              )}
             </FormControl>
           </FormItem>
         ))}

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Gridiron Survivor.
 // Licensed under the MIT License.
 
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import React, { JSX } from 'react';
 import { FormItem, FormControl } from '@/components/Form/Form';
 import { RadioGroup } from '@radix-ui/react-radio-group';
@@ -78,19 +77,17 @@ const WeekTeams = ({
             )}
             <FormItem key={competition.id} className="text-center">
               <FormControl>
-                {loadingTeamName ===
-              competition.team.shortDisplayName.toLowerCase() ? ( <LoadingSpinner/>
-                ) : (
-                  <WeeklyPickButton
+                <WeeklyPickButton
+                  loadingTeamName={loadingTeamName}
+                  selectedTeam={competition.team.shortDisplayName.toLowerCase()}
                   homeAway={competition.homeAway}
-                      team={competition.team.name}
-                      src={competition.team.logo}
-                      isDisabled={
-                      Boolean(loadingTeamName) ||
-                      hasTeamBeenPicked(competition.team.name, selectedTeams)
-                      }
-                    />
-                  )}
+                  team={competition.team.name}
+                  src={competition.team.logo}
+                  isDisabled={
+                    Boolean(loadingTeamName) ||
+                    hasTeamBeenPicked(competition.team.name, selectedTeams)
+                  }
+                />
               </FormControl>
             </FormItem>
           </>

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.tsx
@@ -8,6 +8,7 @@ import { IWeekTeamsProps } from './WeekTeams.interface';
 import { WeeklyPickButton } from '@/components/WeeklyPickButton/WeeklyPickButton';
 import { hasTeamBeenPicked } from '@/utils/utils';
 import { NFLTeams } from '@/api/apiFunctions.enum';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 
 /**
  * Formats the date to 'day, mon date' format and the time to either 12 or 24-hour format based on the user's locale.
@@ -42,6 +43,7 @@ const formatDateTime = (dateString: string): string => {
  * @param props.selectedTeams The user's selected teams.
  * @param props.userPick The user's pick.
  * @param props.onWeeklyPickChange The function to call when the user's pick changes.
+ * @param props.loadingTeam The loading state for selecting teams.
  * @returns The rendered weekly picks page.
  */
 const WeekTeams = ({
@@ -50,6 +52,7 @@ const WeekTeams = ({
   selectedTeams,
   userPick,
   onWeeklyPickChange,
+  loadingTeamName,
 }: IWeekTeamsProps): JSX.Element => (
   <RadioGroup
     onValueChange={(value: string) => onWeeklyPickChange(value as NFLTeams)}
@@ -68,14 +71,15 @@ const WeekTeams = ({
         {scheduledGame.competitions[0].competitors.map((competition) => (
           <FormItem key={competition.id}>
             <FormControl>
+              {loadingTeamName === competition.team.shortDisplayName.toLowerCase() ? <LoadingSpinner/> : 
               <WeeklyPickButton
                 team={competition.team.name}
                 src={competition.team.logo}
-                isDisabled={hasTeamBeenPicked(
+                isDisabled={Boolean(loadingTeamName) || hasTeamBeenPicked(
                   competition.team.name,
                   selectedTeams,
                 )}
-              />
+              />}
             </FormControl>
           </FormItem>
         ))}

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.tsx
@@ -72,18 +72,17 @@ const WeekTeams = ({
           <FormItem key={competition.id}>
             <FormControl>
               {loadingTeamName ===
-              competition.team.shortDisplayName.toLowerCase() ? (
-                <LoadingSpinner />
-              ) : (
-                <WeeklyPickButton
-                  team={competition.team.name}
-                  src={competition.team.logo}
-                  isDisabled={
-                    Boolean(loadingTeamName) ||
+              competition.team.shortDisplayName.toLowerCase() ? ( <LoadingSpinner/>
+                ) : (
+                  <WeeklyPickButton
+                    team={competition.team.name}
+                    src={competition.team.logo}
+                    isDisabled={
+                      Boolean(loadingTeamName) ||
                     hasTeamBeenPicked(competition.team.name, selectedTeams)
-                  }
-                />
-              )}
+                    }
+                  />
+                )}
             </FormControl>
           </FormItem>
         ))}

--- a/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.tsx
+++ b/app/(main)/league/[leagueId]/entry/[entryId]/week/WeekTeams.tsx
@@ -43,7 +43,7 @@ const formatDateTime = (dateString: string): string => {
  * @param props.selectedTeams The user's selected teams.
  * @param props.userPick The user's pick.
  * @param props.onWeeklyPickChange The function to call when the user's pick changes.
- * @param props.loadingTeam The loading state for selecting teams.
+ * @param props.loadingTeamName The loading state for selecting teams.
  * @returns The rendered weekly picks page.
  */
 const WeekTeams = ({

--- a/components/WeeklyPickButton/WeeklyPickButton.stories.tsx
+++ b/components/WeeklyPickButton/WeeklyPickButton.stories.tsx
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof meta>;
 const withRadioGroup: Decorator = (Story) => (
   <RadioGroup>
     <Story />
-    <WeeklyPickButton homeAway='Home' team="Cowboys" src="/assets/team-logo-placeholder.jpg" loadingTeamName={"cowboys"} selectedTeam={"cowboys"} />
+    <WeeklyPickButton homeAway='Home' team="Cowboys" src="/assets/team-logo-placeholder.jpg" loadingTeamName={"ravens"} selectedTeam={""} />
   </RadioGroup>
 );
 
@@ -44,7 +44,7 @@ export const Primary: Story = {
     team: 'Ravens',
     src: '/assets/team-logo-placeholder.jpg',
     loadingTeamName: 'ravens',
-    selectedTeam: 'ravens',
+    selectedTeam: '',
   },
   decorators: withRadioGroup,
 };

--- a/components/WeeklyPickButton/WeeklyPickButton.stories.tsx
+++ b/components/WeeklyPickButton/WeeklyPickButton.stories.tsx
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof meta>;
 const withRadioGroup: Decorator = (Story) => (
   <RadioGroup>
     <Story />
-    <WeeklyPickButton homeAway='Home' team="Cowboys" src="/assets/team-logo-placeholder.jpg" />
+    <WeeklyPickButton homeAway='Home' team="Cowboys" src="/assets/team-logo-placeholder.jpg" loadingTeamName={"cowboys"} selectedTeam={"cowboys"} />
   </RadioGroup>
 );
 
@@ -43,6 +43,8 @@ export const Primary: Story = {
     homeAway: 'Home',
     team: 'Ravens',
     src: '/assets/team-logo-placeholder.jpg',
+    loadingTeamName: 'ravens',
+    selectedTeam: 'ravens',
   },
   decorators: withRadioGroup,
 };

--- a/components/WeeklyPickButton/WeeklyPickButton.test.tsx
+++ b/components/WeeklyPickButton/WeeklyPickButton.test.tsx
@@ -12,27 +12,66 @@ const weeklyPickData = {
 };
 
 describe('WeeklyPickButton', () => {
-  it.each(['Home', 'Away'])('renders correctly with homeAway data', (homeAway) => {
+  it.each(['Home', 'Away'])(
+    'renders correctly with homeAway data',
+    (homeAway) => {
+      render(
+        <RadioGroup>
+          <WeeklyPickButton
+            loadingTeamName={''}
+            selectedTeam={''}
+            homeAway={homeAway}
+            team={weeklyPickData.team}
+            src={weeklyPickData.src}
+          />
+        </RadioGroup>,
+      );
+
+      const homeAwayLabel = screen.getByTestId('home-away');
+      expect(homeAwayLabel).toBeInTheDocument();
+      expect(homeAwayLabel).toHaveTextContent(homeAway);
+
+      const image = screen.getByTestId('team-image');
+
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute('src', weeklyPickData.src);
+
+      const teamName = screen.getByTestId('team-label');
+      expect(teamName).toBeInTheDocument();
+
+      expect(image).toHaveAttribute('width', weeklyPickData.width);
+      expect(image).toHaveAttribute('height', weeklyPickData.height);
+      expect(image).toHaveAttribute('alt', weeklyPickData.alt);
+    },
+  );
+
+  it('the loading spinner should display after team selection', () => {
     render(
       <RadioGroup>
-        <WeeklyPickButton loadingTeamName={''} selectedTeam={''} homeAway={homeAway} team={weeklyPickData.team} src={weeklyPickData.src} />
+        <WeeklyPickButton
+          loadingTeamName={'packers'}
+          selectedTeam={'packers'}
+          homeAway={'Home'}
+          team={weeklyPickData.team}
+          src={weeklyPickData.src}
+        />
       </RadioGroup>,
     );
+    expect(screen.queryByTestId('loading-spinner')).toBeInTheDocument();
+  });
 
-    const homeAwayLabel = screen.getByTestId('home-away');
-    expect(homeAwayLabel).toBeInTheDocument();
-    expect(homeAwayLabel).toHaveTextContent(homeAway);
-
-    const image = screen.getByTestId('team-image');
-
-    expect(image).toBeInTheDocument();
-    expect(image).toHaveAttribute('src', weeklyPickData.src);
-
-    const teamName = screen.getByTestId('team-label');
-    expect(teamName).toBeInTheDocument();
-
-    expect(image).toHaveAttribute('width', weeklyPickData.width);
-    expect(image).toHaveAttribute('height', weeklyPickData.height);
-    expect(image).toHaveAttribute('alt', weeklyPickData.alt);
+  it('the loading spinner should not display after team selection', () => {
+    render(
+      <RadioGroup>
+        <WeeklyPickButton
+          loadingTeamName={''}
+          selectedTeam={'packers'}
+          homeAway={'Home'}
+          team={weeklyPickData.team}
+          src={weeklyPickData.src}
+        />
+      </RadioGroup>,
+    );
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
   });
 });

--- a/components/WeeklyPickButton/WeeklyPickButton.test.tsx
+++ b/components/WeeklyPickButton/WeeklyPickButton.test.tsx
@@ -15,7 +15,7 @@ describe('WeeklyPickButton', () => {
   it.each(['Home', 'Away'])('renders correctly with homeAway data', (homeAway) => {
     render(
       <RadioGroup>
-        <WeeklyPickButton homeAway={homeAway} team={weeklyPickData.team} src={weeklyPickData.src} />
+        <WeeklyPickButton loadingTeamName={''} selectedTeam={''} homeAway={homeAway} team={weeklyPickData.team} src={weeklyPickData.src} />
       </RadioGroup>,
     );
 

--- a/components/WeeklyPickButton/WeeklyPickButton.tsx
+++ b/components/WeeklyPickButton/WeeklyPickButton.tsx
@@ -5,12 +5,15 @@ import React, { JSX } from 'react';
 import Image from 'next/image';
 import { Label } from '../Label/Label';
 import { RadioGroupItem } from '../RadioGroup/RadioGroup';
+import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
 
 type WeeklyPickButtonProps = {
   homeAway: string;
   team: string;
   src: string;
   isDisabled?: boolean;
+  loadingTeamName: string | null;
+  selectedTeam: string;
 };
 
 /**
@@ -20,6 +23,8 @@ type WeeklyPickButtonProps = {
  * @param props.src - The image source
  * @param props.isDisabled - Whether the button is disabled
  * @param props.homeAway - Shows whether the team is home or away.
+ * @param props.loadingTeamName - The loading state for selecting teams.
+ * @param props.selectedTeam - The selected team that the user chose.
  * @returns The rendered weekly pick button.
  */
 const WeeklyPickButton: React.FC<WeeklyPickButtonProps> = ({
@@ -27,6 +32,8 @@ const WeeklyPickButton: React.FC<WeeklyPickButtonProps> = ({
   team,
   src,
   isDisabled = false,
+  loadingTeamName,
+  selectedTeam,
 }): JSX.Element => {
   return (
     <>
@@ -40,6 +47,7 @@ const WeeklyPickButton: React.FC<WeeklyPickButtonProps> = ({
           disabled={isDisabled}
           data-testid="team-radio"
         />
+
         <Label htmlFor={team} data-testid="team-label" disabled={isDisabled}>
           <Image
             src={src}
@@ -50,7 +58,7 @@ const WeeklyPickButton: React.FC<WeeklyPickButtonProps> = ({
             data-testid="team-image"
             className="h-12 w-12"
           />
-          {team}
+          {loadingTeamName === selectedTeam ? <LoadingSpinner /> : <>{team}</>}
         </Label>
       </div>
     </>

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -92,7 +92,7 @@ export const getUserPick = async ({
  * Parse the user pick
  * @param userId - The user id
  * @param entryId - The entry id
- * @param teamName - The team id
+ * @param teamName - The team name
  * @returns {string} The parsed user pick
  */
 export const parseUserPick = (
@@ -101,7 +101,7 @@ export const parseUserPick = (
   teamName: string,
 ): IUserPick => {
   if (!userId || !teamName || !entryId) {
-    throw new Error('User ID and Team ID Required');
+    throw new Error('User ID and Team Name Required');
   }
 
   const parsedData = JSON.parse(

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -92,7 +92,7 @@ export const getUserPick = async ({
  * Parse the user pick
  * @param userId - The user id
  * @param entryId - The entry id
- * @param teamName - The team name
+ * @param teamName - The team id
  * @returns {string} The parsed user pick
  */
 export const parseUserPick = (
@@ -101,7 +101,7 @@ export const parseUserPick = (
   teamName: string,
 ): IUserPick => {
   if (!userId || !teamName || !entryId) {
-    throw new Error('User ID and Team Name Required');
+    throw new Error('User ID and Team ID Required');
   }
 
   const parsedData = JSON.parse(


### PR DESCRIPTION
# What does this PR do?

- [X] When a user selects a team, add the global loading spinner so it shows up in the team's input.
- [X] Disable other teams from being selected until the API responds.
- [X] Unit test for loading spinner being on screen
- [X] Unit test for loading spinner not being on screen

Fixes #513

# Related screenshots/Videos

https://github.com/user-attachments/assets/7396ebcd-da91-4d5b-b498-f39faf0aa529

# Related Issues/PRs

- https://github.com/LetsGetTechnical/gridiron-survivor/issues/513

#  Have you spent some time to check if this issue has been raised before?
Have you Googled for a similar issue or checked our older issues?
- [X] I checked and didn't find similar issue *