### PR TITLE
fix (#340) - contrast on sign-in/sign-ups

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -59,7 +59,7 @@
 
     --primary: 20.5 90.2% 48.2%;
     --primary-muted: 24.6 95% 53.1%;
-    --primary-foreground: 0 0% 98%;
+    --primary-foreground: 240, 6%, 10%;
 
     --secondary: 240 3.7% 15.9%;
     --secondary-muted: 240 5.3% 26.1%;


### PR DESCRIPTION
Requirements: Work with accessibility to determine the best color palettes here. Multiple instances of unreadable text due to choices of colors.

Feedback from @CorinaMurg on accessibility audit of contrast on the sign-up page:

1. **The subtitle paragraph**
- The text is now zinc-500 which gives a contrast ratio of 4.14. We only have to tweak the color a bit to get to a contrast of 4.5. Changing the text color to zinc-400 does the job but then the contrast is very high (which is not necessarily a bad thing but now the subtitle looks like the title). @ryandotfurrer  and I talked about this during our live audit. We'd need to find a text color that gives us a passing contrast but it's a bit more subdued than the title. 

2. **The links also have no contrast**. Do not worry about them, when my PR gets merged in, they'll be taken care of.

3. **The contrast between the white text and the orange background of the button also fails.** We could either make the background darker (which might go against our entire color theme) or make the text dark. Since we use this button style on other pages as well, I'd suggest we leave it to Jayna. This issue is already on her to do list.

Inputs 1 and 2 are already resolved. For 3, the contrast for button text was fixed by changing color to `zinc-900`.
