### PR TITLE
Fix: Password reset email link (#556)

### DIFF
--- a/utils/getBaseUrl.test.ts
+++ b/utils/getBaseUrl.test.ts
@@ -3,9 +3,8 @@ import { getBaseURL } from './getBaseUrl';
 describe('getBaseURL', () => {
   it('should return the correct base URL for production', () => {
     process.env.NEXT_PUBLIC_VERCEL_ENV = 'production';
-    process.env.NEXT_PUBLIC_VERCEL_URL = 'production.com';
     const result = getBaseURL();
-    expect(result).toBe('https://production.com');
+    expect(result).toBe('https://www.gridironsurvivor.com');
   });
 
   it('should return the correct base URL for preview', () => {

--- a/utils/getBaseUrl.ts
+++ b/utils/getBaseUrl.ts
@@ -8,7 +8,7 @@
 export const getBaseURL = (): string => {
   // Check for Vercel production environment
   if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
-    return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
+    return `https://www.gridironsurvivor.com`;
   }
 
   // Check for Vercel preview environment


### PR DESCRIPTION
fixes #556

- production email will now point directly to www.gridironsurvivor.com without using vercel_env system variables.