### PR TITLE
fix: update next.config to use images.remotePatterns (#532)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,7 +18,12 @@ module.exports = {
     ]
   },
   images: {
-    domains: ['a.espncdn.com'],
+    remotePatterns: [{
+      protocol: 'https',
+      hostname: 'a.espncdn.com',
+      port: '',
+      pathname: '/**',
+    }],
   },
   eslint: {
     ignoreDuringBuilds: false,


### PR DESCRIPTION
fixes #532 

we were using domains which is outdated.  next.config now uses remotePatterns.

[https://nextjs.org/docs/app/building-your-application/optimizing/images#remote-images](https://nextjs.org/docs/app/building-your-application/optimizing/images#remote-images)