### PR TITLE
Cody/link to profile edit page

### DIFF
--- a/components/AdminUserSettings/AdminUserSettings.test.tsx
+++ b/components/AdminUserSettings/AdminUserSettings.test.tsx
@@ -66,7 +66,7 @@ describe('AdminUserSettings Component', () => {
     });
   });
 
-  it('should direct to /admin/edit-profile route when the edit profile button is clicked', () => {
+  it('should direct to /account/settings route when the edit profile button is clicked', () => {
     const adminUserSettings = screen.getByTestId('admin-user-settings');
 
     fireEvent.click(adminUserSettings);
@@ -77,7 +77,7 @@ describe('AdminUserSettings Component', () => {
     });
 
     waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/user/edit');
+      expect(mockPush).toHaveBeenCalledWith('/account/settings');
     });
   });
 

--- a/components/AdminUserSettings/AdminUserSettings.tsx
+++ b/components/AdminUserSettings/AdminUserSettings.tsx
@@ -54,7 +54,7 @@ export const AdminUserSettings = (): JSX.Element => {
         <DropdownMenuItem className="cursor-pointer rounded-b-none flex focus:bg-muted">
           <LinkCustom
             className="text-base no-underline hover:text-foreground w-full py-2 px-0 text-muted-foreground hover:underline"
-            href="#"
+            href="/account/settings"
             data-testid="edit-profile-link"
           >
             Edit Profile


### PR DESCRIPTION
Closes #472 

Branched off of [Carlos's PR](https://github.com/LetsGetTechnical/gridiron-survivor/pull/487) where he implement the user dropdown menu

- added `href="/account/settings"` to edit profile link
- Refactored the test to reflect the changes