### PR TITLE
Cody/fix getUserLeagues function

### DIFF
--- a/utils/utils.test.ts
+++ b/utils/utils.test.ts
@@ -207,14 +207,14 @@ describe('utils', () => {
     });
   });
 
-  xdescribe('getUserLeagues', () => {
+  describe('getUserLeagues', () => {
     it('should return the list of leagues the user is a part of', async () => {
       (getCurrentLeague as jest.Mock).mockResolvedValue(mockLeague);
       const result = await getUserLeagues(mockUserData.leagues);
       expect(result).toStrictEqual([mockLeague]);
     });
     it('should return an empty array if the user has no leagues', async () => {
-      const result = await getUserLeagues([]);
+      const result = await getUserLeagues(['']);
       expect(getCurrentLeague).toHaveBeenCalledTimes(0);
       expect(result).toStrictEqual([]);
     });

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -127,7 +127,7 @@ export const parseUserPick = (
 export const getUserLeagues = async (
   leagues: IUser['leagues'],
 ): Promise<ILeague[]> => {
-  if (!leagues || leagues.length === 0) {
+  if (!leagues || leagues[0] === '') {
     return [];
   }
   const userLeagues = leagues.map((league) => {


### PR DESCRIPTION
Closes #484 

Appwrite returns an array with an empty string if the user is not in any leagues
- changed the check to account for this
- modified the test for getUserLeagues