### PR TITLE
Danielle/610-a11y-menu-controls-not-screenreader-accessible

### DIFF
--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -61,8 +61,15 @@ export const Nav = (): JSX.Element => {
       <ul>
         <li>
           <Drawer open={open} onOpenChange={setOpen}>
-            <DrawerTrigger data-testid="drawer-trigger">
-              <Menu className="text-foreground" />
+            <DrawerTrigger 
+            data-testid="drawer-trigger"
+            aria-haspopup='menu'
+            aria-label='open navigation menu'
+            >
+              <Menu 
+              className="text-foreground" 
+              aria-hidden='true'
+              />
             </DrawerTrigger>
             <DrawerContent>
               <DrawerHeader>

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -62,13 +62,13 @@ export const Nav = (): JSX.Element => {
         <li>
           <Drawer open={open} onOpenChange={setOpen}>
             <DrawerTrigger 
-            data-testid="drawer-trigger"
-            aria-haspopup='menu'
-            aria-label='open navigation menu'
+              data-testid="drawer-trigger"
+              aria-haspopup='menu'
+              aria-label='open navigation menu'
             >
               <Menu 
-              className="text-foreground" 
-              aria-hidden='true'
+                className="text-foreground" 
+                aria-hidden='true'
               />
             </DrawerTrigger>
             <DrawerContent>

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -63,8 +63,7 @@ export const Nav = (): JSX.Element => {
           <Drawer open={open} onOpenChange={setOpen}>
             <DrawerTrigger 
               data-testid="drawer-trigger"
-              aria-haspopup='menu'
-              aria-label='open navigation menu'
+              aria-label='menu'
             >
               <Menu 
                 className="text-foreground" 

--- a/components/NavDrawer/NavDrawer.tsx
+++ b/components/NavDrawer/NavDrawer.tsx
@@ -128,8 +128,10 @@ const DrawerTitle = React.forwardRef<
       {...props}
     />
 
-    <DrawerClose>
-      <X />
+    <DrawerClose aria-label='close navigation menu'>
+      <X 
+      aria-hidden='true'
+      />
     </DrawerClose>
   </div>
 ));

--- a/components/NavDrawer/NavDrawer.tsx
+++ b/components/NavDrawer/NavDrawer.tsx
@@ -130,7 +130,7 @@ const DrawerTitle = React.forwardRef<
 
     <DrawerClose aria-label='close navigation menu'>
       <X 
-      aria-hidden='true'
+        aria-hidden='true'
       />
     </DrawerClose>
   </div>


### PR DESCRIPTION
Current State: 
the controls to open and close the navigation menu are represented by icons only, no description. There are also no aria labels to tell screen reader users what these buttons/icons do. This is a big a11y issue.
There was an additional issue discovered, which is that the Shadcn component `Drawer` has a property `aria-haspopup='dialog'` by default, which is incorrect for this usage (should be `aria-haspopup='menu'`).

![GIS hamburger menu before](https://github.com/user-attachments/assets/103e0379-7a7c-46a5-b3ac-2c5f56311c29)
![GIS close menu before](https://github.com/user-attachments/assets/dc531d65-809d-4c29-acf4-76905fdc5763)


Fix:
Overrode default `aria-haspop` property with correct value (`='menu'`) for the hamburger menu button.
Gave SVG icons the property `aria-hidden='true'` to tell screen readers to ignore them.
Gave the open and close buttons `aria-label` properties to tell screen readers what these buttons are for - accessing the navigation menu.

![GIS hamburger menu after](https://github.com/user-attachments/assets/c9436d56-de9a-4dc1-8497-3bdee7b85ab6)
![GIS close menu after](https://github.com/user-attachments/assets/519a6b3f-1247-473a-af83-b46a31467ed2)
